### PR TITLE
Add default parameter value for block tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ const GNOSIS_SAFE_PROXY_INTERFACE = [
 const detectProxyTarget = (
   proxyAddress: string,
   jsonRpcRequest: EIP1193ProviderRequestFunc,
-  blockTag?: BlockTag
+  blockTag: BlockTag = 'latest'
 ): Promise<string | null> =>
   Promise.any([
     // EIP-1167 Minimal Proxy Contract


### PR DESCRIPTION
Hello! You state that blockTag parameter on the function call is optional but do not actually set the default value.

That was the reason the library wasn't detecting the proxy for me but just returning `null`, as I mentioned [here](https://github.com/gnosis/evm-proxy-detection/issues/6#issuecomment-1343024934).

Please feel free to make adjustments in case I missed anything. Thanks for a useful lib ;)